### PR TITLE
Use the parameter --no-proxy

### DIFF
--- a/src/main/resources/smoketest/execute-http-request.bat.ftl
+++ b/src/main/resources/smoketest/execute-http-request.bat.ftl
@@ -39,6 +39,9 @@ set RESPONSE_FILE_PREFIX=http-response.%RANDOM%
 <#elseif (deployed.file??)>
     <#assign wgetCmdLine = wgetCmdLine + ["--post-file=${deployed.file.name}", "--header=\"Content-Type: ${deployed.contentType}\""]/>
 </#if>
+<#if (deployed.container.noProxy?? && deployed.container.noProxy)>
+    <#assign wgetCmdLine = wgetCmdLine + ["--no-proxy"]/>
+</#if>
 
         <#list deployed.headers as header>
             <#assign wgetCmdLine = wgetCmdLine + ["--header=\"${header}\""]/>

--- a/src/main/resources/smoketest/execute-http-request.sh.ftl
+++ b/src/main/resources/smoketest/execute-http-request.sh.ftl
@@ -28,7 +28,9 @@ export ${envVar}
 <#elseif (deployed.file??)>
     <#assign wgetCmdLine = wgetCmdLine + ["--post-file=${deployed.file.name}", "--header=\"Content-Type: ${deployed.contentType}\""]/>
 </#if>
-<#list deployed.headers as header>
+<#if (deployed.container.noProxy?? && deployed.container.noProxy)>
+    <#assign wgetCmdLine = wgetCmdLine + ["--no-proxy"]/>
+</#if><#list deployed.headers as header>
     <#assign wgetCmdLine = wgetCmdLine + ["--header=\"${header}\""]/>
 </#list>
 

--- a/src/main/resources/smoketest/execute-http-request.sh.ftl
+++ b/src/main/resources/smoketest/execute-http-request.sh.ftl
@@ -30,7 +30,8 @@ export ${envVar}
 </#if>
 <#if (deployed.container.noProxy?? && deployed.container.noProxy)>
     <#assign wgetCmdLine = wgetCmdLine + ["--no-proxy"]/>
-</#if><#list deployed.headers as header>
+</#if>
+<#list deployed.headers as header>
     <#assign wgetCmdLine = wgetCmdLine + ["--header=\"${header}\""]/>
 </#list>
 

--- a/src/main/resources/synthetic.xml
+++ b/src/main/resources/synthetic.xml
@@ -18,6 +18,7 @@
         <property name="powershellInstalled" kind="boolean" default="false" required="false" hidden="false"
                   description="Enable to indicate Powershell (V3+) installed on the host associated to the Runner"/>
         <property name="wgetExecutable" hidden="true" default="smoketest\runtime\wget.exe" category="tests"/>
+        <property name="noProxy" kind="boolean" default="false" category="Options" description="Set the option --no-proxy when executing wget. Set by the container as it is the one knowing if it has to go trough the proxy or not."/>
     </type>
 
     <type type="smoketest.ExecutedHttpRequestTest" extends="udm.BaseDeployed"


### PR DESCRIPTION
Use the parameter --no-proxy in the smoke-runner CI indicating if the runner needs to pass trough the proxy or not to execute the smoke test.